### PR TITLE
updates files as well

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,15 @@ interface MemexSettings {
 	memexFolder: string;
 	template: string;
 	destination: string;
+	overwrite: boolean;
 }
 
 const DEFAULT_SETTINGS: Partial<MemexSettings> = {
 	dateFormat: 'YYYY-MM-DD',
 	memexFolder: 'Memex-Local-Sync',
 	template: "",
-	destination: "Clippings"
+	destination: "Clippings",
+	overwrite: false
 }
 
 export default class MemexClipper extends Plugin {
@@ -50,7 +52,8 @@ export default class MemexClipper extends Plugin {
 						fileData.properties,
 						fileData.highlights,
 						this.app.vault,
-						this.settings.destination
+						this.settings.destination,
+						this.settings.overwrite
 					);
 					files.push(clip);
 				}
@@ -65,7 +68,12 @@ export default class MemexClipper extends Plugin {
 				}
 
 			}
-			new Notice(saved_count + " clippings saved")
+
+			if (saved_count == 0 && this.settings.overwrite == false) {
+				new Notice("No new and not overwriting")
+			} else {
+				new Notice(saved_count + " updates made")
+			}
 		});
 
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -61,6 +61,17 @@ export class MemexClipperSettings extends PluginSettingTab {
                     this.plugin.settings.template = value;
                     await this.plugin.saveSettings();
                 }))
+
+        new Setting(containerEl)
+            .setName("Overwrite")
+            .setDesc("Overwrite existing files?")
+            .addToggle((toggle) =>
+                toggle
+                .setValue(this.plugin.settings.overwrite)
+                .onChange(async (value) => {
+                    this.plugin.settings.overwrite = value;
+                    await this.plugin.saveSettings();
+                }))
     }
 }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Added a new setting called "Overwrite" to the plugin's settings menu.
- The "Overwrite" setting determines whether existing files should be overwritten when saving clippings.
- When the "Overwrite" setting is toggled, the plugin's `saveSettings` method is called to save the new setting value.
- The `MemexClipper` class now includes an `overwrite` property that is used when creating or updating clippings.
- The `update` method in the `Clip` class has been implemented to handle overwriting existing clippings.
- The `create` method in the `Clip` class now returns a number indicating whether a new clipping was created or not.
- The `formatProperties` method in the `Clip` class now uses YAML formatting for the clipping's properties.
- The `format` method in the `Clip` class now includes the YAML header and footer when formatting the clipping.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->